### PR TITLE
some bugfixes

### DIFF
--- a/src/main/java/net/arcanamod/blocks/JarBlock.java
+++ b/src/main/java/net/arcanamod/blocks/JarBlock.java
@@ -8,6 +8,7 @@ import net.arcanamod.items.ArcanaItems;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.util.ITooltipFlag;
+import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.BlockItemUseContext;
 import net.minecraft.item.ItemStack;
@@ -106,6 +107,30 @@ public class JarBlock extends Block{
 		}
 		return super.onBlockActivated(state, worldIn, pos, player, handIn, hit);
 	}
+
+	@Override
+	public void harvestBlock(World worldIn, PlayerEntity player, BlockPos pos, BlockState state, @Nullable TileEntity te, ItemStack stack) {
+		if (te instanceof JarTileEntity) {
+			JarTileEntity jte = (JarTileEntity)te;
+			if (!worldIn.isRemote && jte.vis.getHolder(0).getCurrentVis() == 0)
+				spawnDrops(state, worldIn, pos, te, player, stack);
+		}
+	}
+
+	@Override
+	public void onBlockHarvested(World worldIn, BlockPos pos, BlockState state, PlayerEntity player) {
+		TileEntity te = worldIn.getTileEntity(pos);
+		if (te instanceof JarTileEntity) {
+			JarTileEntity jte = (JarTileEntity)te;
+			if (!worldIn.isRemote && jte.vis.getHolder(0).getCurrentVis() != 0){
+				ItemEntity itementity = new ItemEntity(worldIn, pos.getX(), pos.getY(), pos.getZ(), getItem(worldIn, pos, state));
+				itementity.setDefaultPickupDelay();
+				worldIn.addEntity(itementity);
+			}
+		}
+		super.onBlockHarvested(worldIn, pos, state, player);
+	}
+
 
 	public static Direction getYaw(PlayerEntity player) {
 		int yaw = (int)player.rotationYaw;

--- a/src/main/java/net/arcanamod/containers/AspectContainer.java
+++ b/src/main/java/net/arcanamod/containers/AspectContainer.java
@@ -94,8 +94,21 @@ public abstract class AspectContainer extends Container{
 	
 	public void onContainerClosed(@Nonnull PlayerEntity player){
 		super.onContainerClosed(player);
-		if(shouldReturnAspectsOnClose())
+		//quick fix for disappearing aspects from closing research screen while holding any amount of an aspect
+		if (heldCount != 0 ) {
+			for(AspectSlot slot : aspectSlots) {
+				if (slot.getAspect() == heldAspect) {
+					while(heldCount > 0) {
+						heldCount = slot.insert(heldAspect, heldCount, false);
+					}
+					break;
+				}
+			}
+		}
+		//uncertain whether implementation should be here or somewhere else
+		if(shouldReturnAspectsOnClose()) {
 			aspectSlots.forEach(AspectSlot::onClose);
+		}
 	}
 	
 	public boolean shouldReturnAspectsOnClose(){

--- a/src/main/java/net/arcanamod/containers/slots/AspectCraftingResultSlot.java
+++ b/src/main/java/net/arcanamod/containers/slots/AspectCraftingResultSlot.java
@@ -12,6 +12,7 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.container.CraftingResultSlot;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipeType;
 import net.minecraft.util.NonNullList;
 
 import javax.annotation.Nullable;
@@ -30,10 +31,11 @@ public class AspectCraftingResultSlot extends CraftingResultSlot {
 	public ItemStack onTake(PlayerEntity thePlayer, ItemStack stack) {
 		this.onCrafting(stack);
 		net.minecraftforge.common.ForgeHooks.setCraftingPlayer(thePlayer);
-		NonNullList<ItemStack> nonnulllist = thePlayer.world.getRecipeManager().getRecipeNonNull(ArcanaRecipes.Types.ARCANE_CRAFTING_SHAPED, this.craftMatrix, thePlayer.world);
+		NonNullList<ItemStack> nonnulllist;
 		Optional<IArcaneCraftingRecipe> optionalRecipe = thePlayer.world.getRecipeManager().getRecipe(ArcanaRecipes.Types.ARCANE_CRAFTING_SHAPED, this.craftMatrix, thePlayer.world);
 		net.minecraftforge.common.ForgeHooks.setCraftingPlayer(null);
 		if (optionalRecipe.isPresent()){
+			nonnulllist = thePlayer.world.getRecipeManager().getRecipeNonNull(ArcanaRecipes.Types.ARCANE_CRAFTING_SHAPED, this.craftMatrix, thePlayer.world);
 			IArcaneCraftingRecipe recipe = optionalRecipe.get();
 			UndecidedAspectStack[] aspectStacks = recipe.getAspectStacks();
 			if (aspectStacks.length != 0) {
@@ -45,6 +47,7 @@ public class AspectCraftingResultSlot extends CraftingResultSlot {
 				}
 			}
 		}
+		else { nonnulllist = thePlayer.world.getRecipeManager().getRecipeNonNull(IRecipeType.CRAFTING, this.craftMatrix, thePlayer.world); }
 		for(int i = 0; i < nonnulllist.size(); ++i) {
 			ItemStack itemstack = this.craftMatrix.getStackInSlot(i);
 			ItemStack itemstack1 = nonnulllist.get(i);


### PR DESCRIPTION
I'm not sure if the fixes follow the rules and all, but it seems to work. Maybe...

- Normal crafting in an arcane crafting table shouldn't duplicate the wand or allow you to craft infinitely if recipe matrix has slots containing more than one item. 
- Exiting out of the research table while holding an aspect doesn't delete its existence anymore, though I'm not sure whether the implementation is correct.
- Jars should also keep their contents when broken (except for the pressure and vacuum jars). Haven't looked into making the gui icon and itementity match the contents though (if that's possible)