### PR TITLE
Fix crystal clusters spawning far away from nodes

### DIFF
--- a/src/main/java/net/arcanamod/worldgen/NodeFeature.java
+++ b/src/main/java/net/arcanamod/worldgen/NodeFeature.java
@@ -70,7 +70,7 @@ public class NodeFeature extends Feature<NoFeatureConfig>{
 				BlockPos.Mutable pointer = new BlockPos.Mutable(pos);
 				for(int i = 0; i < 40 && successes < (rand.nextInt(5) + 6); i++){
 					// Pick a random block from the ground
-					pointer.move(rand.nextInt(7) - 3, rand.nextInt(5) - 2, rand.nextInt(7) - 3);
+					pointer.setPos(pos).move(rand.nextInt(7) - rand.nextInt(7), rand.nextInt(5) - rand.nextInt(5), rand.nextInt(7) - rand.nextInt(7));
 					if(newWorld.getBlockState(pointer).isAir() || newWorld.getBlockState(pointer).getMaterial().isReplaceable()){
 						// If it has at least one open side,
 						for(Direction value : Direction.values())


### PR DESCRIPTION
This fixes crystal clusters spawning too far away from nodes by resetting the position to the center before apply the random offset. It also subtracts by another random offset instead of a constant to make the clusters generate closer towards the node.